### PR TITLE
fix missing trailing slash in README example cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ ex. `java -jar JvmDowngrader-all.jar -c 52 downgrade -t input.jar output.jar -cp
 Analyze a downgraded zip file for API usages and shade them into the output.
 you can specify multiple targets for bulk operations.
 
-ex. `java -jar JvmDowngrader-all.jar -c 52 shade -p "shade/prefix" -t input.jar output.jar`
+ex. `java -jar JvmDowngrader-all.jar -c 52 shade -p "shade/prefix/" -t input.jar output.jar`
 
 The class version can be replaced with a path to the pre-downgraded api jar to save time, using `-d`.
 


### PR DESCRIPTION
using the command as presented in the README will throw and IllegalArgumentException: https://github.com/unimined/JvmDowngrader/blob/60b7456cedc2d19db770660e620bef8ea41dfdfb/src/main/java/xyz/wagyourtail/jvmdg/compile/ApiShader.java#L86