### PR TITLE
Add some ModuleDescriptor Builder stubs

### DIFF
--- a/java-api/src/java9/java/xyz/wagyourtail/jvmdg/j9/stub/java_base/J_L_M_ModuleDescriptor.java
+++ b/java-api/src/java9/java/xyz/wagyourtail/jvmdg/j9/stub/java_base/J_L_M_ModuleDescriptor.java
@@ -239,6 +239,26 @@ public class J_L_M_ModuleDescriptor implements Comparable<J_L_M_ModuleDescriptor
         return sb.toString();
     }
 
+    public static Builder newModule(String name, Set<Modifier> ms) {
+        Set<Modifier> mods = new HashSet<>(ms);
+        if (mods.contains(Modifier.AUTOMATIC) && mods.size() > 1) {
+            throw new IllegalArgumentException("AUTOMATIC cannot be used with other modifiers");
+        }
+        return new Builder(name, true, mods);
+    }
+
+    public static Builder newModule(String name) {
+        return new Builder(name, true, Collections.emptySet());
+    }
+
+    public static Builder newOpenModule(String name) {
+        return new Builder(name, true, Collections.singleton(Modifier.OPEN));
+    }
+
+    public static Builder newAutomaticModule(String name) {
+        return new Builder(name, true, Collections.singleton(Modifier.AUTOMATIC));
+    }
+
     @Adapter("java/lang/module/ModuleDescriptor$Modifier")
     public enum Modifier {
         OPEN, AUTOMATIC, SYNTHETIC, MANDATED


### PR DESCRIPTION
When VineFlowers is downgraded as java8 and ran on java11, it just get crazy.

Something about loading a java9+ runtime while being downgraded down to java8 make it go crazy.

This doesn't fully fix the issues, this just make it so it doesn't directly crash.