### PR TITLE
add Java25 math-related stubs

### DIFF
--- a/java-api/src/java25/java/xyz/wagyourtail/jvmdg/j25/stub/java_base/J_L_Math.java
+++ b/java-api/src/java25/java/xyz/wagyourtail/jvmdg/j25/stub/java_base/J_L_Math.java
@@ -1,0 +1,129 @@
+package xyz.wagyourtail.jvmdg.j25.stub.java_base;
+
+import xyz.wagyourtail.jvmdg.version.Ref;
+import xyz.wagyourtail.jvmdg.version.Stub;
+
+import static java.lang.Math.multiplyExact;
+import static java.lang.Math.unsignedMultiplyHigh;
+
+public class J_L_Math {
+    
+    @Stub(ref = @Ref("Ljava/lang/Math;"))
+    public static int powExact(int x, int n) {
+        if (n < 0) {
+            throw new ArithmeticException("negative exponent");
+        } else if (n == 0) {
+            return 1;
+        }
+        if (Math.abs(x) <= 1) {
+            if (x < 0) {
+                return (n & 0b1) == 0 ? 1 : -1;
+            }
+            return x;
+        }
+
+        int p = 1;
+        while (n > 1) {
+            if ((n & 0b1) != 0) {
+                p *= x;
+            }
+            x = multiplyExact(x, x);
+            n >>>= 1;
+        }
+        return multiplyExact(p, x);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/Math;"))
+    public static long powExact(long x, int n) {
+        if (n < 0) {
+            throw new ArithmeticException("negative exponent");
+        } else if (n == 0) {
+            return 1;
+        }
+        if (Math.abs(x) <= 1) {
+            if (x < 0) {
+                return (n & 0b1) == 0 ? 1 : -1;
+            }
+            return x;
+        }
+
+        long p = 1;
+        while (n > 1) {
+            if ((n & 0b1) != 0) {
+                p *= x;
+            }
+            x = multiplyExact(x, x);
+            n >>>= 1;
+        }
+        return multiplyExact(p, x);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/Math;"))
+    public static int unsignedMultiplyExact(int x, int y) {
+        long r = (x & 0xFFFF_FFFFL) * (y & 0xFFFF_FFFFL);
+        if (r >>> 32 != 0) {
+            throw new ArithmeticException("unsigned integer overflow");
+        }
+        return (int)r;
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/Math;"))
+    public static long unsignedMultiplyExact(long x, int y) {
+        return unsignedMultiplyExact(x, y & 0xFFFF_FFFFL);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/Math;"))
+    public static long unsignedMultiplyExact(long x, long y) {
+        long l = x * y;
+        long h = unsignedMultiplyHigh(x, y);
+        if (h == 0) {
+            return l;
+        }
+        throw new ArithmeticException("unsigned long overflow");
+    }
+
+    @Stub(ref = @Ref(("Ljava/lang/Math;")))
+    public static int unsignedPowExact(int x, int n) {
+        if (n < 0) {
+            throw new ArithmeticException("negative exponent");
+        } else if (n == 0) {
+            return 1;
+        }
+        if (x == 0 || x == 1) {
+            return x;
+        }
+
+        int p = 1;
+        while (n > 1) {
+            if ((n & 0b1) != 0) {
+                p *= x;
+            }
+            x = unsignedMultiplyExact(x, x);
+            n >>>= 1;
+        }
+        return unsignedMultiplyExact(p, x);
+    }
+
+    @Stub(ref = @Ref(("Ljava/lang/Math;")))
+    public static long unsignedPowExact(long x, int n) {
+        if (n < 0) {
+            throw new ArithmeticException("negative exponent");
+        } else if (n == 0) {
+            return 1;
+        }
+        if (x == 0 || x == 1) {
+            return x;
+        }
+
+        long p = 1;
+        while (n > 1) {
+            if ((n & 0b1) != 0) {
+                p *= x;
+            }
+            x = unsignedMultiplyExact(x, x);
+            n >>>= 1;
+        }
+        return unsignedMultiplyExact(p, x);
+    }
+    
+}

--- a/java-api/src/java25/java/xyz/wagyourtail/jvmdg/j25/stub/java_base/J_L_StrictMath.java
+++ b/java-api/src/java25/java/xyz/wagyourtail/jvmdg/j25/stub/java_base/J_L_StrictMath.java
@@ -1,0 +1,43 @@
+package xyz.wagyourtail.jvmdg.j25.stub.java_base;
+
+import xyz.wagyourtail.jvmdg.version.Ref;
+import xyz.wagyourtail.jvmdg.version.Stub;
+
+public class J_L_StrictMath {
+
+    @Stub(ref = @Ref("Ljava/lang/StrictMath;"))
+    public static int powExact(int x, int n) {
+        return J_L_Math.powExact(x, n);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/StrictMath;"))
+    public static long powExact(long x, int n) {
+        return J_L_Math.powExact(x, n);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/StrictMath;"))
+    public static int unsignedMultiplyExact(int x, int y) {
+        return J_L_Math.unsignedMultiplyExact(x, y);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/StrictMath;"))
+    public static long unsignedMultiplyExact(long x, int y) {
+        return J_L_Math.unsignedMultiplyExact(x, y);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/StrictMath;"))
+    public static long unsignedMultiplyExact(long x, long y) {
+        return J_L_Math.unsignedMultiplyExact(x, y);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/StrictMath;"))
+    public static int unsignedPowExact(int x, int n) {
+        return J_L_Math.unsignedPowExact(x, n);
+    }
+
+    @Stub(ref = @Ref("Ljava/lang/StrictMath;"))
+    public static long unsignedPowExact(long x, int n) {
+        return J_L_Math.unsignedPowExact(x, n);
+    }
+
+}

--- a/java-api/src/main/java/xyz/wagyourtail/jvmdg/providers/Java25Downgrader.java
+++ b/java-api/src/main/java/xyz/wagyourtail/jvmdg/providers/Java25Downgrader.java
@@ -32,8 +32,10 @@ public class Java25Downgrader extends VersionProvider {
         stub(J_I_Reader.class);
         stub(J_L_CharSequence.class);
         stub(J_L_IO.class);
+        stub(J_L_Math.class);
         stub(J_L_R_AccessFlag.class);
         stub(J_L_ScopedValue.class);
+        stub(J_L_StrictMath.class);
         stub(J_U_Currency.class);
         stub(J_U_TimeZone.class);
         stub(J_U_Z_Deflater.class);


### PR DESCRIPTION
This PR adds missing stubs in Java25 `java.lang.Math` and `java.lang.StrictMath`